### PR TITLE
Der Zugriff auf die Session und die Config hat sich in Version 4.9.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Die neue Artikelreihenfolge wird sofort gespeichert mit der ersten Änderung.
 
 Hinweise
 --------
-Die OXID Version 4.7.3 hat im Frontend eine feste Sortierung implementiert (default =  "Titel").
-Die Sortierung in der Datenbank wird hier nicht berücksichtigt.
+Funktioniert mit Oxid Version 4.9.x
 
 Autor
 ------
@@ -17,7 +16,7 @@ Autor
 
 Version
 -------
-1.0
+1.0.1
 
 Installation
 ============
@@ -28,6 +27,7 @@ Installation
 
 3. Dateien/Verzeichnisse in "categoryorder" kopieren
 
+3.1. !kopiere! die Datei Shop-Verzeichnis/modules/oe/vendormetadata.php nach Shop-Verzeichnis/modules/marm/
 4. Modul aktivieren
 
 5. Cache löschen.

--- a/controllers/admin/marm_category_order.php
+++ b/controllers/admin/marm_category_order.php
@@ -38,7 +38,7 @@ class marm_category_order extends oxAdminDetails
         $this->_aViewData['edit'] = $oCategory = oxNew( 'oxcategory' );
 
         // resetting
-        oxSession::setVar( 'neworder_sess', null );
+        oxRegistry::getSession()->setVariable( 'neworder_sess', null );
 
         $soxId = $this->getEditObjectId();
 
@@ -54,7 +54,7 @@ class marm_category_order extends oxAdminDetails
                 $this->_aViewData['readonly'] = true;
             }
         }
-        if ( oxConfig::getParameter("aoc") ) {
+        if ( oxRegistry::getConfig()->getRequestParameter("aoc") ) {
             return "marm_category_order_popup.tpl";
         }
         return "marm_category_order.tpl";
@@ -71,8 +71,8 @@ class marm_category_order extends oxAdminDetails
     {
         $success = '';
         
-        $sortedList = oxConfig::getParameter("sortedList");
-        $catId = oxConfig::getParameter("catId");
+        $sortedList = oxRegistry::getConfig()->getRequestParameter("sortedList");
+        $catId = oxRegistry::getConfig()->getRequestParameter("catId");
         
         $newsortedList = explode('&', str_replace('ID[]=', '', $sortedList));
         $result = count($newsortedList);

--- a/metadata.php
+++ b/metadata.php
@@ -16,7 +16,7 @@ $aModule = array(
         'en'            => 'Sort the products of a category in backend via drag & drop.',
     ),
     'thumbnail'    => 'marmalade.jpg',
-    'version'      => '1.0',
+    'version'      => '1.0.1',
     'author'       => 'Konstantin Kuznetsov',
     'url'          => 'http://www.marmalade.de',
     'email'        => 'support@marmalade.de',

--- a/views/tpl/popups/marm_headitem.tpl
+++ b/views/tpl/popups/marm_headitem.tpl
@@ -18,7 +18,7 @@
                     $(counterDiv).html( index + 1 );
                 });
                 $.ajax({
-                        type: "GET",
+                        type: "POST",
                         url: "[{$oViewConf->getSelfLink()}]",
                         data: {
                             cl: "marm_category_order",


### PR DESCRIPTION
geändert. Durch die Anpassung läuft das Modul jetzt in der 4.9.x Version.

Die Anpassung von GET auf POST im Popup-Template war nötig, da in unserem
konkreten Fall die Update-URL aufgrund der Masse von Artikeln in der Kategorie
zu lang wurde und einen JS-Fehler verursacht hat.
